### PR TITLE
use precise hex float value for CEIL

### DIFF
--- a/src/main/java/com/github/tommyettinger/digital/MathTools.java
+++ b/src/main/java/com/github/tommyettinger/digital/MathTools.java
@@ -178,7 +178,7 @@ public final class MathTools {
 
     private static final int BIG_ENOUGH_INT = 16 * 1024;
     private static final double BIG_ENOUGH_FLOOR = BIG_ENOUGH_INT;
-    private static final double CEIL = 0.9999999;
+    private static final double CEIL = 0x1.fffffep-1f; // was 0.9999999
     private static final double BIG_ENOUGH_ROUND = BIG_ENOUGH_INT + 0.5f;
 
     /**


### PR DESCRIPTION
this value is equivalent to tacking an extra 4 at the end of the original 0.9999999, and the ceil methods that use this new value are successful for inputs as small as 0x1p-24 (IEEE machine epsilon)